### PR TITLE
Make buffer object private

### DIFF
--- a/bin/influx_remembering_file_tailer.pl
+++ b/bin/influx_remembering_file_tailer.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib::projectroot qw(lib local::lib=local);
+
+# ABSTRACT: Tail files and send them to influxdb for live stats
+
+package Runner;
+use Moose;
+extends 'InfluxDB::Writer::RememberingFileTailer';
+with 'MooseX::Getopt';
+
+use Log::Any::Adapter ('Stderr');
+
+my $runner = Runner->new_with_options->run;
+

--- a/lib/InfluxDB/Writer/FileTailer.pm
+++ b/lib/InfluxDB/Writer/FileTailer.pm
@@ -32,12 +32,20 @@ has 'flush_interval' =>
 has 'tags' => ( is => 'ro', isa => 'HashRef', predicate => 'has_tags' );
 has '_files' => ( is => 'ro', isa => 'HashRef', default => sub { {} } );
 has '_loop' => ( is => 'ro', isa => 'IO::Async::Loop', lazy_build => 1 );
+has 'buffer' => ( is => 'ro', isa => 'ArrayRef[Str]', default => sub { [] }, traits => ['Array'],
+    handles => {
+        buffer_push => 'push',
+        buffer_all => 'elements',
+        buffer_size => 'count',
+        buffer_splice => 'splice',
+        buffer_is_empty => 'is_empty',
+    },
+
+);
 
 sub _build__loop {
     return IO::Async::Loop->new;
 }
-
-my @buffer;
 
 sub run {
     my $self = shift;
@@ -139,10 +147,10 @@ sub setup_file_watcher {
                     if ( $self->has_tags ) {
                         $line = $self->add_tags_to_line($line);
                     }
-                    push( @buffer, $line );
+                    $self->buffer_push($line);
                 }
 
-                if ( @buffer > $self->flush_size ) {
+                if ( $self->buffer_size > $self->flush_size ) {
                     $self->send;
                 }
 
@@ -161,37 +169,66 @@ sub setup_file_watcher {
 
 sub send {
     my ($self) = @_;
-    return unless @buffer;
+
+    my $current_size = $self->buffer_size;
+    return unless $current_size;
+
+    my @to_send = $self->buffer_splice(0, $current_size);
 
     my %args;
     if ( $self->_with_auth ) {
         $args{head} = [ "Authorization" => $self->_auth_header ];
     }
-
-    $log->debugf( "Sending %i lines to influx", scalar @buffer );
+    $log->debugf( "Sending %i lines to influx", scalar @to_send);
     my $res = Hijk::request(
         {   method       => "POST",
             host         => $self->influx_host,
             port         => $self->influx_port,
             path         => "/write",
             query_string => "db=" . $self->influx_db,
-            body         => join( "\n", @buffer ),
+            body         => join( "\n", @to_send ),
             %args,
         }
     );
+    if (my $current_error = $res->{error}) {
+
+        my @errs = (qw/
+            CONNECT_TIMEOUT
+            READ_TIMEOUT
+            TIMEOUT
+            CANNOT_RESOLVE
+            REQUEST_SELECT_ERROR
+            REQUEST_WRITE_ERROR
+            REQUEST_ERROR
+            RESPONSE_READ_ERROR
+            RESPONSE_BAD_READ_VALUE
+            RESPONSE_ERROR
+            /);
+
+        my @matches;
+        foreach my $err (@errs) {
+            my $const = eval "Hijk::Error::" . $err;
+            if ( $current_error & $const ) {
+                push(@matches, $err);
+            }
+        }
+
+        $log->errorf("Hijk Request Error(s) cannot send %s", join(", ", @matches));
+
+        return;
+    
+    }
     if ( $res->{status} != 204 ) {
         $log->errorf(
             "Could not send %i lines to influx: %s",
-            scalar @buffer,
+            scalar @to_send,
             $res->{body}
         );
 
-        @buffer = ();
         return;
     }
 
-    @buffer = ();
-    return 1;
+    return scalar(@to_send);
 }
 
 sub add_tags_to_line {

--- a/lib/InfluxDB/Writer/RememberingFileTailer.pm
+++ b/lib/InfluxDB/Writer/RememberingFileTailer.pm
@@ -1,0 +1,111 @@
+package InfluxDB::Writer::RememberingFileTailer;
+
+use Moose;
+our $VERSION = '1.000';
+use feature 'say';
+
+use IO::Async::File;
+use IO::Async::FileStream;
+use IO::Async::Loop;
+use Hijk ();
+use Carp qw(croak);
+use InfluxDB::LineProtocol qw(line2data data2line);
+use Log::Any qw($log);
+use File::Spec::Functions;
+use File::Spec qw(splitpath);
+
+extends 'InfluxDB::Writer::FileTailer';
+my @buffer = @{\@InfluxDB::Writer::FileTailer::buffer};
+
+has 'done_dir' => ( is => 'rw', isa => "Str" );
+
+before 'run' => sub {
+    my $self = shift;
+
+    my $done_dir = catdir($self->dir, 'done');
+    if ( -d $done_dir ) {
+        $self->done_dir($done_dir);
+    } else {
+        croak "Missing 'done' directory, please create: " . $done_dir;
+    }
+
+};
+
+sub archive_file {
+    my $self = shift;
+    my $file = shift;
+
+    my $done_dir = $self->done_dir;
+    my ($vol, $dirs, $basename) = File::Spec->splitpath($file);
+
+    if ( rename($file, catfile($done_dir, $basename)) ) {
+        $log->infof("Archived file %s to %s", $basename ,$done_dir);
+        return 1;
+    }
+    else {
+        $log->errorf("Failed to archive %s to %s", $basename ,$done_dir);
+        croak "Failed to archive $file";
+        return 0;
+    }
+
+}
+
+=head2 slurp_and_send
+
+IO::Async read operations are blocking so it does not make sense to wrice
+complicated async code here. We want to read the files that are left over and
+send them to influx asap, then move them to the archive folder (aka. out of the
+way)
+
+=cut
+
+sub slurp_and_send {
+    my $self = shift;
+    my $file = shift;
+
+    if ( open( my $fh, "<", $file ) ) {
+        $log->infof( "Slurping %s", $file );
+
+        while (my $line = <$fh>) {
+            if ( $self->has_tags ) {
+                $line = $self->add_tags_to_line($line);
+            }
+            push(@buffer, $line);
+
+            if ( @buffer > $self->flush_size ) {
+                $self->send or return;
+            }
+        }
+
+        if (scalar @buffer ) {
+            $log->infof( "Clear buffer (size %i) for file %s", scalar(@buffer), $file );
+            $self->send or return;
+        }
+
+        $log->infof( "Finished slurping %s", $file );
+
+        return 1;
+    }
+
+    return;
+
+}
+
+
+override 'archive_hook' => sub {
+    shift->archive_file(@_);
+    super();
+};
+
+override 'cleanup_hook' => sub {
+    my ($self, $file) = @_;
+    
+    if ($self->slurp_and_send($file)) {
+        $self->archive_file($file);
+    }
+    return super();
+
+};
+
+
+1;

--- a/lib/InfluxDB/Writer/RememberingFileTailer.pm
+++ b/lib/InfluxDB/Writer/RememberingFileTailer.pm
@@ -73,13 +73,19 @@ sub slurp_and_send {
             push(@buffer, $line);
 
             if ( @buffer > $self->flush_size ) {
-                $self->send or return;
+                if (!$self->send) {
+                    $log->warnf("Unable to send buffer (%i lines)", scalar @buffer);
+                    return;
+                }
             }
         }
 
         if (scalar @buffer ) {
             $log->infof( "Clear buffer (size %i) for file %s", scalar(@buffer), $file );
-            $self->send or return;
+            if (!$self->send) {
+                $log->warnf("Unable to send clear buffer (%i lines)", scalar @buffer);
+                return;
+            }
         }
 
         $log->infof( "Finished slurping %s", $file );


### PR DESCRIPTION
Hi,

I wonder why buffer was a global? The callbacks have always been called with $self?

Anyway, this would help the "remembering" file tailer that can be run anytime and will move the finished archives to $stats/done.

lg,k
